### PR TITLE
Implemented workaround for a bug in the libesedb library

### DIFF
--- a/src/cache/meta_data_cache.rs
+++ b/src/cache/meta_data_cache.rs
@@ -81,7 +81,12 @@ impl TryFrom<&EsedbInfo<'_>> for MetaDataCache {
         let mut record_by_guid = HashMap::new();
         let mut root = None;
         //let mut root_dse = None;
-        let count = info.data_table().count_records()?;
+        let count = match info.data_table().count_records() {
+            Ok(x) => x,
+            Err(_) => {
+                info.data_table().count_records()? as i32
+            }
+        };
         let bar = crate::create_progressbar(
             "Creating cache for record IDs".to_string(),
             count.try_into()?,
@@ -96,7 +101,7 @@ impl TryFrom<&EsedbInfo<'_>> for MetaDataCache {
                         let cn = Rdn::from_record_opt(&record, cn_column)?;
                         let object_category =
                             RecordId::from_record_opt(&record, object_category_column)?;
-                        let sid = Sid::from_record_opt(&record, sid_column)?;
+                        let sid = Sid::from_record_opt(&record, sid_column).unwrap_or(None);
                         let guid = Guid::from_record_opt(&record, guid_column)?;
 
                         if let Some(attribute_id) =

--- a/src/cache/record/mod.rs
+++ b/src/cache/record/mod.rs
@@ -90,9 +90,15 @@ impl<'info, 'db> Record<'info, 'db> {
         esedbinfo: &'info EsedbInfo<'db>,
         columns: Rc<ColumnsOfTable>,
     ) -> std::io::Result<Self> {
+        let count: i32 = match record.count_values() {
+            Ok(x) => x,
+            Err(_) => {
+                record.count_values()? as i32
+            }
+        };
         Ok(Self {
             values: Default::default(),
-            count: record.count_values()?,
+            count,
             record,
             esedbinfo,
             table_id,

--- a/src/cache/table/data_table.rs
+++ b/src/cache/table/data_table.rs
@@ -40,12 +40,18 @@ where
         esedbinfo: &'info EsedbInfo<'db>,
         metadata: MetaDataCache,
     ) -> std::io::Result<Self> {
+        let count: i32 = match table.count_records() {
+            Ok(x) => x,
+            Err(_) => {
+                table.count_records()? as i32
+            }
+        };
         Ok(Self {
             table,
             table_id,
             esedbinfo,
             metadata,
-            number_of_records: table.count_records()?,
+            number_of_records: count,
             columns: Rc::new(ColumnsOfTable::try_from(table)?),
         })
     }

--- a/src/column_info_mapping.rs
+++ b/src/column_info_mapping.rs
@@ -28,7 +28,13 @@ impl TryFrom<&Table<'_>> for ColumnInfoMapping {
     fn try_from(data_table: &Table) -> Result<Self, Self::Error> {
         let mut mapping = HashMap::new();
         let mut str_mapping = HashMap::new();
-        for index in 0..data_table.count_columns()? {
+        let count = match data_table.count_columns() {
+            Ok(x) => x,
+            Err(_) => {
+                data_table.count_columns()? as i32
+            }
+        };
+        for index in 0..count {
             let column = data_table.column(index)?;
             let col_info = ColumnInformation::new(index);
             if let Ok(column_id) = NtdsAttributeId::try_from(&column.name()?[..]) {


### PR DESCRIPTION
I noticed a bug in libesedb that fails counting values, rows or tables in some `NTDS.dit` files. 
This was also present when using the newest libesedb version.
Even `esedbexport` fails here.
A workaround for this is to just execute the count function again if it fails and for some reason it will work the second time.

After changing this, the tool would crash when parsing an invalid SID.
There might be a better way, but i've just changed the behavior to set the SID to `None` when the parser fails instead of throwing an error.