### PR TITLE
23 feature request allows to display timestamp in iso8601 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,86 @@ OPTIONS:
     -q, --quiet              Less output per occurrence
     -v, --verbose            More output per occurrence
 ```
+
+
+## Configuring the global timestamp format
+
+Per default, `ntdsextract2` uses an RFC3339-compliant data format. If you want to, you can change the data format
+being used by setting the `DFIR_DATE` environment variable. Let's look at an example:
+
+```shell
+$ ntdsextract2 tests/data/ntds_plain.dit user -F json-lines |jq 'select (.rdn == "Administrator")'
+```
+
+```json
+{
+  "sid": "S-1-5-21-1467604378-2733498025-3532005688-500",
+  "user_principal_name": null,
+  "rdn": "Administrator",
+  "sam_account_name": "Administrator",
+  "sam_account_type": "SAM_USER_OBJECT",
+  "user_account_control": "ADS_UF_NORMAL_ACCOUNT | ADS_UF_DONT_EXPIRE_PASSWD",
+  "logon_count": 4,
+  "bad_pwd_count": 0,
+  "admin_count": null,
+  "is_deleted": false,
+  "primary_group_id": 513,
+  "primary_group": "Domänen-Benutzer",
+  "member_of": [
+    "Richtlinien-Ersteller-Besitzer",
+    "Schema-Admins",
+    "Administratoren",
+    "Organisations-Admins",
+    "Domänen-Admins"
+  ],
+  "comment": null,
+  "record_time": "2023-11-15T06:33:44+0000",
+  "when_created": "2023-11-15T06:33:44+0000",
+  "when_changed": "2023-11-15T06:41:50+0000",
+  "last_logon": "2023-11-15T06:41:50+0000",
+  "last_logon_time_stamp": "2023-11-15T06:41:50+0000",
+  "account_expires": "+30828-09-14T02:48:05+0000",
+  "password_last_set": "2023-11-15T05:40:32+0000",
+  "bad_pwd_time": "1601-01-01T00:00:00+0000"
+}
+```
+
+
+```shell
+$ DFIR_DATE="%F %T (%Z)" ntdsextract2 tests/data/ntds_plain.dit user -F json-lines |jq 'select (.rdn == "Administrator")'
+```
+
+```json
+{
+  "sid": "S-1-5-21-1467604378-2733498025-3532005688-500",
+  "user_principal_name": null,
+  "rdn": "Administrator",
+  "sam_account_name": "Administrator",
+  "sam_account_type": "SAM_USER_OBJECT",
+  "user_account_control": "ADS_UF_NORMAL_ACCOUNT | ADS_UF_DONT_EXPIRE_PASSWD",
+  "logon_count": 4,
+  "bad_pwd_count": 0,
+  "admin_count": null,
+  "is_deleted": false,
+  "primary_group_id": 513,
+  "primary_group": "Domänen-Benutzer",
+  "member_of": [
+    "Administratoren",
+    "Schema-Admins",
+    "Domänen-Admins",
+    "Organisations-Admins",
+    "Richtlinien-Ersteller-Besitzer"
+  ],
+  "comment": null,
+  "record_time": "2023-11-15 06:33:44 (UTC)",
+  "when_created": "2023-11-15 06:33:44 (UTC)",
+  "when_changed": "2023-11-15 06:41:50 (UTC)",
+  "last_logon": "2023-11-15 06:41:50 (UTC)",
+  "last_logon_time_stamp": "2023-11-15 06:41:50 (UTC)",
+  "account_expires": "+30828-09-14 02:48:05 (UTC)",
+  "password_last_set": "2023-11-15 05:40:32 (UTC)",
+  "bad_pwd_time": "1601-01-01 00:00:00 (UTC)"
+}
+```
+
+See the difference?

--- a/src/win32_types/timestamp/mod.rs
+++ b/src/win32_types/timestamp/mod.rs
@@ -22,7 +22,7 @@ lazy_static! {
     );
 }
 
-static DATE_FORMAT: &str = "%d-%m-%YT%H:%M:%S%z";
+static DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";
 
 #[macro_export]
 macro_rules! impl_timestamp {

--- a/src/win32_types/timestamp/mod.rs
+++ b/src/win32_types/timestamp/mod.rs
@@ -1,16 +1,16 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{format::StrftimeItems, DateTime, FixedOffset, NaiveDate, Utc};
 use lazy_static::lazy_static;
 
 mod database_time;
-mod truncated_windows_file_time;
-mod windows_file_time;
-mod unix_timestamp;
 mod timeline_entry;
+mod truncated_windows_file_time;
+mod unix_timestamp;
+mod windows_file_time;
 
-pub use truncated_windows_file_time::TruncatedWindowsFileTime;
-pub use windows_file_time::WindowsFileTime;
-pub use unix_timestamp::*;
 pub use timeline_entry::*;
+pub use truncated_windows_file_time::TruncatedWindowsFileTime;
+pub use unix_timestamp::*;
+pub use windows_file_time::WindowsFileTime;
 
 lazy_static! {
     static ref BASE_DATETIME: DateTime<Utc> = DateTime::<Utc>::from_naive_utc_and_offset(
@@ -22,7 +22,35 @@ lazy_static! {
     );
 }
 
-static DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";
+lazy_static! {
+    pub static ref TIMESTAMP_FORMAT: String = {
+        if let Ok(format) = std::env::var("DFIR_DATE") {
+            if StrftimeItems::new(&format).any(|i| i == chrono::format::Item::Error) {
+                eprintln!();
+                eprintln!("ERROR: invalid date format: '{format}' stored in environment variable $DFIR_DATE!");
+                eprintln!();
+                eprintln!("Please take a look at");
+                eprintln!();
+                eprintln!(
+                    "        <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>"
+                );
+                eprintln!();
+                eprintln!("to see which format strings are accepted.");
+                eprintln!();
+                std::process::exit(-1);
+            } else {
+                format
+            }
+        } else {
+            // use this format, because to_rfc3339 creates values like '+30828-09-14T02:48:05.477580+00:00',
+            // which cannot be parsed with parse_from_rfc3339()
+            "%Y-%m-%dT%H:%M:%S%z".to_string()
+        }
+    };
+    pub static ref ZERO: DateTime<FixedOffset> =
+        DateTime::<FixedOffset>::parse_from_rfc3339("0000-00-00T00:00:00+00:00")
+            .expect("unable to parse literal timestamp");
+}
 
 #[macro_export]
 macro_rules! impl_timestamp {
@@ -34,7 +62,10 @@ macro_rules! impl_timestamp {
                 match value {
                     $crate::cache::Value::Currency(val) => Ok(Some($type::from(*val))),
                     $crate::cache::Value::Null(()) => Ok(None),
-                    _ => Err($crate::ntds::Error::InvalidValueDetected(value.to_string(), stringify!($type))),
+                    _ => Err($crate::ntds::Error::InvalidValueDetected(
+                        value.to_string(),
+                        stringify!($type),
+                    )),
                 }
             }
         }
@@ -44,23 +75,23 @@ macro_rules! impl_timestamp {
             where
                 S: serde::Serializer,
             {
-                serializer.serialize_str(&self.0.format($crate::win32_types::timestamp::DATE_FORMAT).to_string())
+                serializer.serialize_str(&self.0.format(&$crate::win32_types::timestamp::TIMESTAMP_FORMAT).to_string())
             }
         }
 
         impl<'de> serde::Deserialize<'de> for $type {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: serde::Deserializer<'de> {
-                
-            use serde::de;
-            let buf = String::deserialize(deserializer)?;
-            match DateTime::parse_from_str(&buf[..], $crate::win32_types::timestamp::DATE_FORMAT) {
-                Ok(dt) => Ok(Self(dt.with_timezone(&Utc))),
-                Err(why) => Err(de::Error::custom(format!(
-                    "unable to parse timestamp '{buf}': {why}"
-                ))),
-            }
+                D: serde::Deserializer<'de>,
+            {
+                use serde::de;
+                let buf = String::deserialize(deserializer)?;
+                match DateTime::parse_from_str(&buf[..], &$crate::win32_types::timestamp::TIMESTAMP_FORMAT) {
+                    Ok(dt) => Ok(Self(dt.with_timezone(&Utc))),
+                    Err(why) => Err(de::Error::custom(format!(
+                        "unable to parse timestamp '{buf}': {why}"
+                    ))),
+                }
             }
         }
 

--- a/tests/test_plain.rs
+++ b/tests/test_plain.rs
@@ -1,35 +1,38 @@
 use std::{
+    collections::HashMap,
     io::{BufReader, Cursor},
-    path::PathBuf, collections::HashMap,
+    path::PathBuf,
 };
 
 use assert_cmd::Command;
 use libntdsextract2::{ntds::Person, CsvSerialization};
-
 
 #[test]
 fn test_plain() {
     let dstfile = get_test_data("ntds_plain.dit");
 
     let mut cmd = Command::cargo_bin("ntdsextract2").unwrap();
-    let result = cmd.arg(dstfile).arg("user").ok();
+    let result = cmd
+        .arg(dstfile)
+        .arg("user")
+        .ok();
 
     match &result {
         Ok(out) => {
             let mut users = HashMap::new();
             let reader = BufReader::new(Cursor::new(&out.stdout));
             let mut rdr = csv::Reader::from_reader(reader);
-            
+
             for result in rdr.deserialize() {
                 let record: Person<CsvSerialization> = result.unwrap();
                 users.insert(record.sam_account_name().as_ref().unwrap().clone(), record);
             }
 
             assert!(users.contains_key("Administrator"));
-            assert!(! users.contains_key("InvalidUser"));
+            assert!(!users.contains_key("InvalidUser"));
 
             let admin = users.get("Administrator").unwrap();
-            assert!(! admin.is_deleted())
+            assert!(!admin.is_deleted())
         }
         Err(why) => {
             println!("{why}");


### PR DESCRIPTION
- fix invalid default timestamp format to be `%Y-%m-%dT%H:%M:%S%z`
- allow users to change the format using the `DFIR_DATE` environment variable